### PR TITLE
Parslet 1.4 error

### DIFF
--- a/bin/check_lucene_query
+++ b/bin/check_lucene_query
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require "lucene_query_parser"
-require "rainbow"
+require 'rainbow/ext/string'  # not recommended but live dangerously
 
 if ARGV.include?("-h") || ARGV.include?("--help")
   name = __FILE__

--- a/lib/lucene_query_parser/parser.rb
+++ b/lib/lucene_query_parser/parser.rb
@@ -11,24 +11,9 @@ module LuceneQueryParser
       parse query
       nil
     rescue Parslet::ParseFailed => error
-      cause = find_cause root.error_tree
+      cause = error.cause.ascii_tree
       cause =~ /line (\d+) char (\d+)/
       {:line => $1.to_i, :column => $2.to_i, :message => cause}
-    end
-
-    # Recursively find a "real" cause within a Parslet error tree. "Real"
-    # causes contain line/column positions.
-    def find_cause(node)
-      if node.parslet.cause
-        node.cause
-      else
-        # go in reverse to find the last thing that failed rather than the first
-        node.children.reverse.each do |child|
-          if cause = find_cause(child)
-            return cause
-          end
-        end
-      end
     end
 
     # ----- grammar definition -----

--- a/lib/lucene_query_parser/version.rb
+++ b/lib/lucene_query_parser/version.rb
@@ -1,3 +1,3 @@
 module LuceneQueryParser
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,4 +3,6 @@ require "lucene_query_parser"
 require "parslet/rig/rspec"
 
 RSpec.configure do |config|
+  config.raise_errors_for_deprecations!
+  config.expect_with(:rspec) { |c| c.syntax = :should }
 end


### PR DESCRIPTION
parslet version 1.4 eliminated the error_tree method. This PR simplifies the error reporting, along with small updates for use with latest rspec and rainbow dependencies.
