### PR TITLE
Allow ranges to be decimals and dates.

### DIFF
--- a/lib/lucene_query_parser/parser.rb
+++ b/lib/lucene_query_parser/parser.rb
@@ -67,14 +67,14 @@ module LuceneQueryParser
 
     rule :inclusive_range do
       str('[') >> space.maybe >>
-      (word | range_wildcard).as(:from) >> space >> str('TO') >> space >> 
-      (word | range_wildcard).as(:to) >> space.maybe >> str(']')
+      (range_word | range_wildcard).as(:from) >> space >> str('TO') >> space >>
+      (range_word | range_wildcard).as(:to) >> space.maybe >> str(']')
     end
 
     rule :exclusive_range do
       str('{') >> space.maybe >>
-      (word | range_wildcard).as(:from) >> space >> str('TO') >> space >> 
-      (word | range_wildcard).as(:to) >> space.maybe >> str('}')
+      (range_word | range_wildcard).as(:from) >> space >> str('TO') >> space >>
+      (range_word | range_wildcard).as(:to) >> space.maybe >> str('}')
     end
 
     rule :unary_operator do
@@ -101,6 +101,10 @@ module LuceneQueryParser
 
     rule :word do
       match["\\w"].repeat(1)
+    end
+
+    rule :range_word do
+      match["0-9a-z\\-."].repeat(1)
     end
 
     rule :space do

--- a/spec/lucene_query_parser/parser_spec.rb
+++ b/spec/lucene_query_parser/parser_spec.rb
@@ -174,6 +174,22 @@ describe LuceneQueryParser::Parser do
       {:field => "day", :exclusive_range => {:from => "11", :to => "*"}}
     ) }
 
+    it { should parse('foo:[0.5 TO 1]').as(
+      {:field => "foo", :inclusive_range => {:from => "0.5", :to => "1"}}
+    ) }
+
+    it { should parse('foo:[2015-05-05 TO 2015-06-06]').as(
+      {:field => "foo", :inclusive_range => {:from => "2015-05-05", :to => "2015-06-06"}}
+    ) }
+
+    it { should parse('foo:{0.5 TO 1}').as(
+      {:field => "foo", :exclusive_range => {:from => "0.5", :to => "1"}}
+    ) }
+
+    it { should parse('foo:{2015-05-05 TO 2015-06-06}').as(
+      {:field => "foo", :exclusive_range => {:from => "2015-05-05", :to => "2015-06-06"}}
+    ) }
+
     it { should parse('boosted^1').as({:term => "boosted", :boost => "1"})}
     it { should parse('boosted^0.1').as({:term => "boosted", :boost => "0.1"})}
 


### PR DESCRIPTION
Right now you cannot do

foo:[0.5 TO 1] nor date:[2015-05-06 TO 2015-06-06]
